### PR TITLE
feat: add dark/light theme switcher with icon transition

### DIFF
--- a/client/grao-a-grao/src/components/AppSidebar.tsx
+++ b/client/grao-a-grao/src/components/AppSidebar.tsx
@@ -24,6 +24,8 @@ import { useStoreContext } from "@/context/StoreContext";
 import { useState } from "react";
 import { ModalFormLogout } from "@/components/Form/Modal/ModalLogoutConfirmation";
 
+import { ThemeSwitcher } from "./ThemeSwitcher";
+
 // Menu items.
 const items = [
   {
@@ -133,6 +135,7 @@ export function AppSidebar() {
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem>
+                  <ThemeSwitcher/>
                   <SidebarMenuButton className="cursor-pointer" asChild>
                     <div
                       onClick={() => {

--- a/client/grao-a-grao/src/components/StoreSwitcher.tsx
+++ b/client/grao-a-grao/src/components/StoreSwitcher.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/sidebar";
 import { StoreModel } from "@/types/store";
 import { useStoreContext } from "@/context/StoreContext";
+import { Text, Flex } from "@radix-ui/themes";
 
 export function StoreSwitcher({
   onStoreChange,
@@ -37,15 +38,15 @@ export function StoreSwitcher({
               size="lg"
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer"
             >
-              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-accent">
+              <Flex justify="center" align="center" direction="row" className="aspect-square size-8 rounded-(--radius-3) bg-sidebar-accent">
                 <GalleryVerticalEnd className="size-4" />
-              </div>
-              <div className="flex flex-col gap-0.5 leading-none">
-                <span className="font-semibold">Loja</span>
-                <span>
+              </Flex>
+              <Flex direction="column" className="leading-none">
+                <Text weight="medium">Loja</Text>
+                <Text>
                   {selectedStore ? selectedStore.name : "Selecione uma loja"}
-                </span>
-              </div>
+                </Text>
+              </Flex>
               <ChevronDown
                 className={`ml-auto transition-transform duration-500 ${
                   menuOpen ? "rotate-180" : ""

--- a/client/grao-a-grao/src/components/ThemeSwitcher.tsx
+++ b/client/grao-a-grao/src/components/ThemeSwitcher.tsx
@@ -4,6 +4,7 @@ import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 import { Moon, Sun } from 'lucide-react';
 import { SidebarMenuButton } from '@/components/ui/sidebar';
+import { Box, Text } from '@radix-ui/themes';
 
 export function ThemeSwitcher() {
   const { resolvedTheme, setTheme } = useTheme();
@@ -21,7 +22,7 @@ export function ThemeSwitcher() {
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
       aria-label="Alternar tema"
     >
-      <div className="relative w-4 h-4">
+      <Box className="relative w-4 h-4">
         <Sun
           className={`
             absolute top-0 left-0 w-4 h-4
@@ -38,9 +39,9 @@ export function ThemeSwitcher() {
           `}
           strokeWidth={2}
         />
-      </div>
+      </Box>
 
-      <span>Tema</span>
+      <Text>Tema</Text>
     </SidebarMenuButton>
   );
 }

--- a/client/grao-a-grao/src/components/ThemeSwitcher.tsx
+++ b/client/grao-a-grao/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { SidebarMenuButton } from '@/components/ui/sidebar';
+
+export function ThemeSwitcher() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const isDark = resolvedTheme === 'dark';
+
+  return (
+    <SidebarMenuButton
+      className="cursor-pointer flex items-center gap-2"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      aria-label="Alternar tema"
+    >
+      <div className="relative w-4 h-4">
+        <Sun
+          className={`
+            absolute top-0 left-0 w-4 h-4
+            transition duration-800 ease-in-out
+            ${isDark ? 'opacity-100 scale-100' : 'opacity-0 scale-75 pointer-events-none'}
+          `}
+          strokeWidth={2}
+        />
+        <Moon
+          className={`
+            absolute top-0 left-0 w-4 h-4
+            transition duration-800 ease-in-out
+            ${isDark ? 'opacity-0 scale-75 pointer-events-none' : 'opacity-100 scale-100'}
+          `}
+          strokeWidth={2}
+        />
+      </div>
+
+      <span>Tema</span>
+    </SidebarMenuButton>
+  );
+}


### PR DESCRIPTION
Adds a dark/light theme toggle button with animated icons (sun and moon lucide-react), allowing the user to manually switch the application theme regardless of the browser's preference.

 - Next.js with next-themes: for theme control using setTheme and resolvedTheme.
 - Lucide-react: Sun and Moon icons used as visual theme indicators.
 - Tailwind CSS: Smooth transition animation using transition-opacity, transition-transform, duration-800, and ease-in-out.
 - Alternating icon visibility via utility classes (opacity, scale, pointer-events-none).
 - Componentization: Created a reusable ThemeSwitcher component used in the SidebarFooter.
 - Mounting fallback with useState and useEffect to ensure rendering after hydration.